### PR TITLE
Fix build on FreeBSD/powerpc64*

### DIFF
--- a/src/smack1.c
+++ b/src/smack1.c
@@ -138,6 +138,13 @@ unsigned long long rdtsc(void)
   }
   return 0;
 }
+#elif defined(__powerpc64__)
+unsigned long long __rdtsc(void)
+{
+  unsigned long long rval;
+  __asm__ __volatile__("mfspr %%r3, 268": "=r" (rval));
+  return rval;
+}
 #endif
 #elif defined (__llvm__)
 #if defined(i386) || defined(__i386__)


### PR DESCRIPTION
powerpc64 needs to read from TBR to implement a feature similar to RDTSC.