### PR TITLE
PROTO-MC: Add support for Minecraft's protocol.

### DIFF
--- a/src/masscan-app.c
+++ b/src/masscan-app.c
@@ -42,7 +42,8 @@ masscan_app_to_string(enum ApplicationProtocol proto)
     case PROTO_TELNET:         return "telnet";
     case PROTO_RDP:            return "rdp";
     case PROTO_HTTP_SERVER:     return "http.server";
-            
+    case PROTO_MC:     return "minecraft";
+
     default:
         sprintf_s(tmp, sizeof(tmp), "(%u)", proto);
         return tmp;
@@ -89,10 +90,11 @@ masscan_string_to_app(const char *str)
         {"telnet",      PROTO_TELNET},
         {"rdp",         PROTO_RDP},
         {"http.server", PROTO_HTTP_SERVER},
+        {"minecraft",   PROTO_MC},
         {0,0}
     };
     size_t i;
-    
+
     for (i=0; list[i].name; i++) {
         if (strcmp(str, list[i].name) == 0)
             return list[i].value;

--- a/src/masscan-app.h
+++ b/src/masscan-app.h
@@ -37,7 +37,8 @@ enum ApplicationProtocol {
     PROTO_TELNET,
     PROTO_RDP,          /* Microsoft Remote Desktop Protocol tcp/3389 */
     PROTO_HTTP_SERVER,  /* HTTP "Server:" field */
-    
+    PROTO_MC,           /* Minecraft server */
+
     PROTO_end_of_list /* must be last one */
 };
 

--- a/src/proto-banner1.h
+++ b/src/proto-banner1.h
@@ -125,6 +125,13 @@ struct FTPSTUFF {
     unsigned is_last:1;
 };
 
+struct MCSTUFF {
+    char * banmem;
+    size_t totalLen;
+    size_t imgstart;
+    size_t imgend;
+    int brackcount;
+};
 
 struct SMTPSTUFF {
     unsigned code;
@@ -246,6 +253,7 @@ struct ProtocolState {
         struct MEMCACHEDSTUFF memcached;
         struct SMBSTUFF smb;
         struct RDPSTUFF rdp;
+        struct MCSTUFF mc;
     } sub;
 };
 

--- a/src/proto-mc.c
+++ b/src/proto-mc.c
@@ -1,0 +1,115 @@
+#include "proto-mc.h"
+#include "proto-banner1.h"
+#include "unusedparm.h"
+#include "masscan-app.h"
+#include "proto-interactive.h"
+#include "output.h"
+#include <ctype.h>
+#include <string.h>
+#include <stdlib.h>
+
+static unsigned char hand_shake_ptr[128];
+
+unsigned char* hand_shake(uint16_t port, const char* ip,size_t ip_len)
+{
+    size_t tlen = 10+ip_len;
+    unsigned char * ret = (unsigned char *)calloc(1,tlen);
+    ret[0] = 7+ip_len;
+    ret[2] = 0xf7;
+    ret[3] = 5;
+    ret[4] = ip_len;
+    memcpy(ret+5,ip,ip_len);
+    ret[tlen-5] = (unsigned char)(port>>8);
+    ret[tlen-4] = (unsigned char)(port&0xff);
+    ret[tlen-3] = 1;
+    ret[tlen-2] = 1;
+    ret[tlen-1] = 0;
+    return ret;
+}
+
+void* memstr(void * mem, size_t len, char * str)
+{
+    size_t stlen = strlen(str);
+    if(len < stlen)
+        return 0;
+    for(size_t i = 0; i < len-stlen; i++) {
+        if(!memcmp(mem+i,str,stlen))
+            return mem+i;
+    }
+    return 0;
+}
+
+/***************************************************************************
+ ***************************************************************************/
+static void
+mc_parse(  const struct Banner1 *banner1,
+          void *banner1_private,
+          struct ProtocolState *pstate,
+          const unsigned char *px, size_t length,
+          struct BannerOutput *banout,
+          struct InteractiveData *more)
+{
+    struct MCSTUFF *mc = &pstate->sub.mc;
+
+    for(size_t i = 0; i < length; i++) {
+        if(px[i] == '{')
+            mc->brackcount++;
+        if(px[i] == '}')
+            mc->brackcount--;
+    }
+    if(mc->brackcount <= 0)
+        more->is_closing = 1;
+
+    if((mc->imgstart&&mc->imgend) || mc->brackcount <= 0) { // we already found and removed image data
+        banout_append(banout, PROTO_MC,px,length);
+    } else {
+        mc->banmem = realloc(mc->banmem,mc->totalLen+length+1); // expand to add new memory for added paket
+        memcpy(mc->banmem+mc->totalLen,px,length); // copy in new packet
+        mc->banmem[mc->totalLen] = 0; // add ending 0 for str
+        mc->totalLen+=length;
+        if(!mc->imgstart) { // dont search again if we found start
+            mc->imgstart = (size_t)memstr(mc->banmem,mc->totalLen,"data:image/png;base64");
+            if(mc->imgstart)
+                mc->imgstart-=(size_t)mc->banmem;
+        } else { // we found start but not the end
+            if((mc->imgend = (size_t)memchr(mc->banmem+mc->imgstart,'\"',mc->totalLen-mc->imgstart))){ // we found the end
+                mc->imgend-=(size_t)mc->banmem;
+                memcpy(mc->banmem+mc->imgstart,mc->banmem+mc->imgend,(mc->totalLen-mc->imgend)+1); // copy data after B64
+                mc->totalLen=mc->imgstart+(mc->totalLen-mc->imgend); // shrink length to subtract B64 image
+                banout_append(banout, PROTO_MC,mc->banmem,mc->totalLen); // print out banner minus image data
+                free(mc->banmem); // we dont need to keep track of this any more.
+            }
+        }
+    }
+}
+
+/***************************************************************************
+ ***************************************************************************/
+static void *
+mc_init(struct Banner1 *banner1)
+{
+    unsigned char * tmp = hand_shake(25565,"localhost",9);
+    memcpy(hand_shake_ptr,tmp,tmp[0]+3);
+    free(tmp);
+    banner_mc.hello = hand_shake_ptr;
+    banner_mc.hello_length = hand_shake_ptr[0]+3;
+    banner1->payloads.tcp[25565] = (void*)&banner_mc;
+    return 0;
+}
+
+/***************************************************************************
+ ***************************************************************************/
+static int
+mc_selftest(void)
+{
+    return 0;
+}
+
+/***************************************************************************
+ ***************************************************************************/
+struct ProtocolParserStream banner_mc = {
+    "mc", 25565, 0, 0, 0,
+    mc_selftest,
+    mc_init,
+    mc_parse,
+};

--- a/src/proto-mc.h
+++ b/src/proto-mc.h
@@ -1,0 +1,8 @@
+#ifndef PROTO_MC_H
+#define PROTO_MC_H
+#include "proto-banner1.h"
+#include "util-bool.h"
+
+extern struct ProtocolParserStream banner_mc;
+
+#endif


### PR DESCRIPTION
Scanning for Minecraft serves is a popular thing to do. Add basic support for detecting Minecraft servers.

Signed-off-by: Jesse Taube <Mr.Bossman075@gmail.com>